### PR TITLE
Successfully fix tool duplication

### DIFF
--- a/commands/cleanChamfer/entry.py
+++ b/commands/cleanChamfer/entry.py
@@ -217,7 +217,7 @@ def patch_faces(selections: adsk.core.SelectionCommandInput, sew: bool):
         tg = tgs.add(firstTLN.index, secondTLN.index)
 
     timing = timer.finish()
-    if config.DEBUG:
+    if config.TIMING:
         futil.log(format_timer(timing))
 
 def are_vectors_parallel(vector1: adsk.core.Vector3D, vector2: adsk.core.Vector3D, tol: float = 1e-6) -> bool:

--- a/commands/updateTools/entry.py
+++ b/commands/updateTools/entry.py
@@ -146,7 +146,7 @@ class LibraryTool:
         if self.document_index == -1:
             dtl.add(self.tool)
             self.document_index = dtl.count - 1
-        futil.log(f'Library Tool {dict(self.tool.toJson())["description"]}: {self.tool.toJson()==dtl.item(self.document_index).toJson()}')
+        futil.log(f'Library Tool : {self.tool.toJson()==dtl.item(self.document_index).toJson()}')
         return dtl.item(self.document_index)
 
 

--- a/commands/updateTools/entry.py
+++ b/commands/updateTools/entry.py
@@ -136,20 +136,18 @@ def remove_tip_keys(tool: dict) -> dict: # APIDUMB: For some reason when you get
 
 class LibraryTool:
     tool: Tool
-    used_already: bool
-    document_index: int
+    document_tool: Tool = None
     def __init__(self, tool: Tool):
         self.tool = tool
-        self.document_index = -1
 
     def get_tool(self, dtl: DocumentToolLibrary) -> Tool:
-        if self.document_index == -1:
+        if self.document_tool is None:
             dtl.add(self.tool)
-            self.document_index = dtl.count - 1
-        doc = json.loads(dtl.item(self.document_index).toJson(), parse_float=lambda x: round(float(x), 3))
+            self.document_tool = dtl.item(dtl.count - 1)
+        doc = json.loads(self.document_tool.toJson(), parse_float=lambda x: round(float(x), 3))
         local = json.loads(self.tool.toJson(), parse_float=lambda x: round(float(x), 3))
-        futil.log(f'Library Tool {local["description"]} - {doc["description"]}: {self.tool.toJson()==dtl.item(self.document_index).toJson()}')
-        return dtl.item(self.document_index)
+        futil.log(f'Library Tool {local["description"]} - {doc["description"]}: {self.tool.toJson()==self.document_tool.toJson()}')
+        return self.document_tool
 
 
 def replace_with_library_tool(operations: List[adsk.cam.Operation], library: ToolLibrary, correlation_type: str):

--- a/commands/updateTools/entry.py
+++ b/commands/updateTools/entry.py
@@ -146,7 +146,9 @@ class LibraryTool:
         if self.document_index == -1:
             dtl.add(self.tool)
             self.document_index = dtl.count - 1
-        futil.log(f'Library Tool : {self.tool.toJson()==dtl.item(self.document_index).toJson()}')
+        doc = json.loads(dtl.item(self.document_index).toJson(), parse_float=lambda x: round(float(x), 3))
+        local = json.loads(self.tool.toJson(), parse_float=lambda x: round(float(x), 3))
+        futil.log(f'Library Tool {local["description"]} - {doc["description"]}: {self.tool.toJson()==dtl.item(self.document_index).toJson()}')
         return dtl.item(self.document_index)
 
 

--- a/commands/updateTools/entry.py
+++ b/commands/updateTools/entry.py
@@ -146,7 +146,7 @@ class LibraryTool:
         if self.document_index == -1:
             dtl.add(self.tool)
             self.document_index = dtl.count - 1
-        futil.log(f'Library Tool {self.tool.toJson()["description"]}: {self.tool.toJson()==dtl.item(self.document_index).toJson()}')
+        futil.log(f'Library Tool {dict(self.tool.toJson())["description"]}: {self.tool.toJson()==dtl.item(self.document_index).toJson()}')
         return dtl.item(self.document_index)
 
 

--- a/commands/updateTools/entry.py
+++ b/commands/updateTools/entry.py
@@ -146,6 +146,7 @@ class LibraryTool:
         if self.document_index == -1:
             dtl.add(self.tool)
             self.document_index = dtl.count - 1
+        futil.log(f'Library Tool {self.tool.toJson()["description"]}: {self.tool.toJson()==dtl.item(self.document_index).toJson()}')
         return dtl.item(self.document_index)
 
 
@@ -164,7 +165,7 @@ def replace_with_library_tool(operations: List[adsk.cam.Operation], library: Too
         tool_json = json.loads(tool.toJson(), parse_float=lambda x: round(float(x), 3)) # APIDUMB: All the floats coming out of a newly opened file are .3f so we need to do this so the hash matches
         library_tool_used.append(LibraryTool(tool))
         lib_num = library_tool_used.__len__() - 1
-        futil.log(f'Library Tool: {tool.toJson()==library_tool_used[lib_num].tool.toJson()}')
+        
         library_tool_description[tool_json["description"]] = lib_num
         library_tool_product_ids[tool_json["product-id"]] = lib_num
         if "geometry" in tool_json.keys():

--- a/commands/updateTools/entry.py
+++ b/commands/updateTools/entry.py
@@ -163,13 +163,15 @@ def replace_with_library_tool(operations: List[adsk.cam.Operation], library: Too
         tool: Tool = library.item(i)
         tool_json = json.loads(tool.toJson(), parse_float=lambda x: round(float(x), 3)) # APIDUMB: All the floats coming out of a newly opened file are .3f so we need to do this so the hash matches
         library_tool_used.append(LibraryTool(tool))
-        library_tool_description[tool_json["description"]] = library_tool_used.__len__() - 1
-        library_tool_product_ids[tool_json["product-id"]] = library_tool_used.__len__() - 1
+        lib_num = library_tool_used.__len__() - 1
+        futil.log(f'Library Tool: {tool.toJson()==library_tool_used[lib_num].tool.toJson()}')
+        library_tool_description[tool_json["description"]] = lib_num
+        library_tool_product_ids[tool_json["product-id"]] = lib_num
         if "geometry" in tool_json.keys():
             geometry = json.dumps(remove_tip_keys(tool_json["geometry"]))
             geometry_hash = sha256(geometry.encode()).hexdigest()
             geom_debug += f'{geometry_hash}: \"{geometry}\"\n'
-            library_tool_geometry_hash[geometry_hash] = library_tool_used.__len__() - 1
+            library_tool_geometry_hash[geometry_hash] = lib_num
     geom_debug += "Setup tools: \n"
     for operation in operations:
         tool = operation.tool

--- a/config.py
+++ b/config.py
@@ -9,6 +9,10 @@ import os
 # to set this to True while developing an add-in and set it to False when you
 # are ready to distribute it.
 DEBUG = True
+TIMING = False
+if os.path.exists('.env'):
+    TIMING = True
+
 
 # Gets the name of the add-in from the name of the folder the py file is in.
 # This is used when defining unique internal names for various UI elements 


### PR DESCRIPTION
For some reason when you set a tool for a operation it checks to see if that tool (by pointer) is already in the DocumentToolLibrary, as the pointer we hold through python is to a Tool in the ToolLibrary (that is something that is not the Document) it would make a copy
Now if we are going to add a tool, we add it to the DocumentToolLibrary first and then hand all future operations that use that tool a pointer into the DocumentToolLibrary