### PR TITLE
Fix NoneType when material library not found

### DIFF
--- a/commands/colorHoles/entry.py
+++ b/commands/colorHoles/entry.py
@@ -299,8 +299,11 @@ def mk_color(rgb: rgbCl):
     if myColor:
         return myColor
     else:
-        # Get the existing Yellow appearance.            
-        fusionMaterials = app.materialLibraries.itemByName('Fusion 360 Appearance Library')
+        # Get the existing Yellow appearance.
+        if config.DEBUG:
+            for i in range(app.materialLibraries.count):
+                futil.log(f"{app.materialLibraries.item(i).name} {app.materialLibraries.item(i).id}")    
+        fusionMaterials = app.materialLibraries.itemByName('Fusion Appearance Library')
         yellowColor = fusionMaterials.appearances.itemByName('Paint - Enamel Glossy (Yellow)')
         
         # Copy it to the design, giving it a new name.

--- a/config.py
+++ b/config.py
@@ -8,10 +8,11 @@ import os
 # more information is written to the Text Command window. Generally, it's useful
 # to set this to True while developing an add-in and set it to False when you
 # are ready to distribute it.
-DEBUG = True
+DEBUG = False
 TIMING = False
 if os.path.exists('.env'):
     TIMING = True
+    DEBUG = True
 
 
 # Gets the name of the add-in from the name of the folder the py file is in.


### PR DESCRIPTION
At some time at of after the rebrand of Fusion 360 to Fusion, the 'Fusion 360 Material Library' where the yellow enamel appearence that is used as the template for the colored surface comes from, had its name changed to 'Fusion Material Library' breaking the functionality
The functionality has been restored and debuging has been added